### PR TITLE
Exclude Solvers from Coverage Report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,4 +45,10 @@ jacocoTestReport {
         xml.enabled = true
         html.enabled = true
     }
+
+    afterEvaluate {
+        classDirectories = files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['**/Cplex.class', '**/Gurobi.class', '**/SolverFactory.class', '**/Main.class'])
+        })
+    }
 }


### PR DESCRIPTION
Since Gurobi and CPLEX can not be tested on Travis, exclude those solvers from the coverage report.